### PR TITLE
Adds shebang to wrapper.py

### DIFF
--- a/galaxy/mzml2isa/wrapper.py
+++ b/galaxy/mzml2isa/wrapper.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import sys
 import json
 import os


### PR DESCRIPTION
we need a shebang for smoother compatibility with Galaxy-Kubernetes runner. We normally add this types of wrapper to the container, but they need to be self executables. Shouldn't affect normal python wrapper.py execution.
