### PR TITLE
Changes full_parse verbose to avoid GUI elements

### DIFF
--- a/galaxy/mzml2isa/wrapper.py
+++ b/galaxy/mzml2isa/wrapper.py
@@ -211,7 +211,7 @@ def main():
         from mzml2isa.parsing import full_parse
         # import progressbar as pb
         # parse the files
-        full_parse(args.inputzip, args.out_dir, args.study_title, usermeta=USERMETA, split=True, merge=False, verbose=False,
+        full_parse(args.inputzip, args.out_dir, args.study_title, usermeta=USERMETA, split=True, merge=False, verbose=True,
                    multip=False)
 
     except ImportError:


### PR DESCRIPTION
When using verbose=False on full_parse, the underlying mzml2isa parsing.py code makes use of a UI widget (ProgressBar) which is not defined when using wrapper.py in the command line based manner. mzml2isa makes the check of such UI elements being available at its run method (before invoking full_parse method), but since wrapper.py executes full_parse directly, this check never takes place. 

This fixes the following error issued in Galaxy:

``` bash
Traceback (most recent call last):
  File "/usr/local/bin/wrapper.py", line 235, in <module>
    main()
  File "/usr/local/bin/wrapper.py", line 215, in main
    multip=False)
  File "/usr/local/lib/python2.7/dist-packages/mzml2isa/parsing.py", line 217, in full_parse
    pbar = pb.ProgressBar(widgets=['Parsing {:8}: '.format(study_identifier),
NameError: global name 'pb' is not defined
```

This PR only changes the verbose parameter to True to avoid the UI element. The only noticeable difference, besides avoiding the error, will be that mzml2isa.parsing will make seven additional prints to the stdout.
