### PR TITLE
Discovers ISA files as individual files and as Zip file

### DIFF
--- a/galaxy/mzml2isa/mzml2isa.xml
+++ b/galaxy/mzml2isa/mzml2isa.xml
@@ -171,7 +171,10 @@
                --organism_variant_iri "$organism_variant_iri"
                --organism_part_text "$organism_part_text"
                --organism_part_ref "$organism_part_ref"
-               --organism_part_iri "$organism_part_iri"]]>
+	       --organism_part_iri "$organism_part_iri";
+
+	       ln -s "$html_file.extra_files_path"/"$name_of_study" study_dir;
+	       ]]>
     </command>
 
     <inputs>
@@ -185,7 +188,21 @@
         <expand macro="icontactmacro"/>
     </inputs>
     <outputs>
+<!--
+Notes:
+
+- Multiple a_ files
+- Single s_ as per mzml2isa definition (ISA does allow more than one s_ file).
+- Single i_ file.
+--> 
         <data format="html" name="html_file" label="" />
+          <collection type="list" label="A Files" name="a_files">
+		<discover_datasets pattern="(?P&lt;designation&gt;a_.+)\.txt" directory="study_dir" format="tabular"/>
+	  </collection>
+	<collection type="list" label="S Files" name="s_files">
+		<discover_datasets pattern="(?P&lt;designation&gt;s_.+)\.txt" directory="study_dir" format="tabular"/>
+	</collection>
+	<data name="i_file" format="tabular" label="I File" from_work_dir="study_dir/i_Investigation.txt" visible="true"/>
     </outputs>
     <tests>
         <test>

--- a/galaxy/mzml2isa/mzml2isa.xml
+++ b/galaxy/mzml2isa/mzml2isa.xml
@@ -174,6 +174,9 @@
 	       --organism_part_iri "$organism_part_iri";
 
 	       ln -s "$html_file.extra_files_path"/"$name_of_study" study_dir;
+
+	       cd study_dir;
+	       zip isa.zip i_* a_* s_* && mv isa.zip "$ISA_zip";
 	       ]]>
     </command>
 
@@ -196,6 +199,7 @@ Notes:
 - Single i_ file.
 --> 
         <data format="html" name="html_file" label="" />
+        <data name="ISA_zip" format="zip" label="ISA Zip file"/>
           <collection type="list" label="A Files" name="a_files">
 		<discover_datasets pattern="(?P&lt;designation&gt;a_.+)\.txt" directory="study_dir" format="tabular"/>
 	  </collection>


### PR DESCRIPTION
This PR addresses issue #3 by providing both the individual files (collections for a_ and s_ files) and  all the ISA files in a Zip. The second alternative is provided to keep the file names of the ISA files (Galaxy remanes them when "transforming" them recognized datasets).
