### PR TITLE
Makes explicit mention to TAR support

### DIFF
--- a/galaxy/mzml2isa/mzml2isa.xml
+++ b/galaxy/mzml2isa/mzml2isa.xml
@@ -124,7 +124,12 @@
     #end if
 
 
-    wrapper.py -inputzip "$inputzip"
+    wrapper.py 
+    #if $data_file.input == "zip_file":
+               -inputzip "$data_file.zip_input"
+    #else
+               -inputzip "$data_file.tar_input"
+    #end if
                -jsontxt "$jsontxt"
                -html_file "$html_file"
                -out_dir .
@@ -182,7 +187,18 @@
 
     <inputs>
         <param name="name_of_study" type="text" label="Name study" help="This should not contain any spaces as the name will be used a prefix for ISA-tab file names" />
-        <param format="zip" name="inputzip" type="data" label="mzML zip file"  help="A zipped folder of mzML files"/>
+        <conditional name="data_file">
+            <param name="input" type="select" label="Choose your inputs method" >
+                <option value="zip_file" selected="true">Zip file from your history containing your mzML files</option>
+                <option value="tar_file">TAR file from your history containing your mzML files</option>
+            </param>
+            <when value="zip_file">
+		<param format="zip" name="zip_input" type="data" label="mzML zip file"  help="A zipped folder of mzML files"/>
+	    </when>
+            <when value="tar_file">
+		<param format="tar" name="tar_input" type="data" label="mzML TAR file"  help="A tarred folder of mzML files"/>
+	    </when>
+        </conditional>
         <param optional="true" format="txt" name="jsontxt" type="data" label="Additional user Metadata in json"  help="A user can add additional metadata directory through a json file"/>
         <expand macro="studymacro"/>
         <expand macro="investmacro"/>

--- a/galaxy/mzml2isa/wrapper.py
+++ b/galaxy/mzml2isa/wrapper.py
@@ -44,7 +44,7 @@ def main():
                             '''))
 
 
-    p.add_argument('-inputzip', dest='inputzip', required=True)
+    p.add_argument('-inputzip', dest='inputzip', required=True, help="Provide a Zip or TAR file")
     p.add_argument('-out_dir', dest='out_dir', required=True)
     p.add_argument('-html_file', dest='html_file', required=True)
     p.add_argument('-study_title', dest='study_title', required=True)


### PR DESCRIPTION
Only to signal that, down the line, full_parse supports on this position both Zip and TAR files. Didn't want to change the argument name to avoid API changes, but you might want to consider that for a backwards incompatible release in the future.
