### PR TITLE
1.1.1+galaxy1 - Add missing zip dependency

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -156,64 +156,6 @@ jobs:
         name: 'Python linting output'
         path: pylint_report.txt
 
-  lintr:
-    name: Lint R scripts
-    needs: setup
-    if: ${{ needs.setup.outputs.repository-list != '' }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04]
-        r-version: ['release']
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 1
-    - uses: r-lib/actions/setup-r@v2
-      with:
-        r-version: ${{ matrix.r-version }}
-    - name: Cache R packages
-      uses: actions/cache@v3
-      with:
-        path: ${{ env.R_LIBS_USER }}
-        key: r_cache_${{ matrix.os }}_${{ matrix.r-version }}
-    - name: Install non-R lintr dependencies
-      run: sudo apt-get install libcurl4-openssl-dev
-    - name: Install lintr
-      run: |
-        install.packages('remotes')
-        remotes::install_cran("lintr")
-      shell: Rscript {0}
-    - name: Save repositories to file
-      run: echo '${{ needs.setup.outputs.repository-list }}' > repository_list.txt
-    - name: lintr
-      run: |
-        library(lintr)
-        linters <- linters_with_defaults(line_length_linter = NULL, cyclocomp_linter = NULL, object_usage_linter = NULL)
-        con <- file("repository_list.txt", "r")
-        status <- 0
-        while (TRUE) {
-          repo <- readLines(con, n = 1)
-          if (length(repo) == 0) {
-             break
-          }
-          lnt <- lint_dir(repo, relative_path=T, linters=linters)
-          if (length(lnt) > 0) {
-            status <- 1
-            for (l in lnt) {
-              rel_path <- paste(repo, l$filename, sep="/")
-              write(paste(paste(rel_path, l$line_number, l$column_number, sep=":"), l$message, paste("(", l$line, ")")), stderr())
-              write(paste(paste(rel_path, l$line_number, l$column_number, sep=":"), l$message, paste("(", l$line, ")")), "rlint_report.txt", append=TRUE)
-            }
-          }
-        }
-        quit(status = status)
-      shell: Rscript {0}
-    - uses: actions/upload-artifact@v3
-      if: ${{ failure() }}
-      with:
-        name: 'R linting output'
-        path: rlint_report.txt
 
   file_sizes:
     name: Check file sizes
@@ -362,7 +304,7 @@ jobs:
   # deploy the tools to the toolsheds (first TTS for testing)
   deploy:
     name: Deploy
-    needs: [setup, lint, flake8, lintr, combine_outputs]
+    needs: [setup, lint, flake8, combine_outputs]
     if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'ISA-tools' }}
     runs-on: ubuntu-latest
     strategy:
@@ -399,7 +341,7 @@ jobs:
 
   determine-success:
     name: Check workflow success
-    needs: [setup, lint, flake8, lintr, file_sizes, combine_outputs]
+    needs: [setup, lint, flake8, file_sizes, combine_outputs]
     if: ${{ always() && github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
@@ -408,9 +350,6 @@ jobs:
       run: exit 1
     - name: Indicate Python script lint status
       if: ${{ needs.flake8.result != 'success' && needs.flake8.result != 'skipped' }}
-      run: exit 1
-    - name: Indicate R script lint status
-      if: ${{ needs.lintr.result != 'success' && needs.lintr.result != 'skipped' }}
       run: exit 1
     - name: Indicate file size check status
       if: ${{ needs.file_sizes.result != 'success' && needs.file_sizes.result != 'skipped' }}

--- a/README.md
+++ b/README.md
@@ -34,11 +34,15 @@ GNU General Public License v3 (GPLv3)
 
 Changes
 -------------------------
+v1.1.1+galaxy1
+  - Fix dependency issues 
+
 v1.1.1+galaxy0
   - Version bump to mzml2isa 1.1.1
   - Galaxy tool python3 compatible (https://github.com/ISA-tools/mzml2isa-galaxy/issues/10)
   - Removed functionality to add additional usermeta data for ISA directly via individual Galaxy Tool inputs (deemed unpractical - and is suited for a separate tool). A JSON file can still be used for this functionality  
-  - Highlight tar option more clearly (https://github.com/ISA-tools/mzml2isa-galaxy/issues/6)
+  - Highlight tar option more clearly (https://github.com/ISA-tools/mzml2isa-galaxy/pull/5)
+  - Bug fixed for json handling (https://github.com/ISA-tools/mzml2isa-galaxy/issues/6)
   - CI/CD updates
 
 v0.1.0

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ GNU General Public License v3 (GPLv3)
 Changes
 -------------------------
 v1.1.1+galaxy1
-  - Fix dependency issues 
+  - Fix dependency issues - specifically required "zip" 
 
 v1.1.1+galaxy0
   - Version bump to mzml2isa 1.1.1

--- a/galaxy/mzml2isa/mzml2isa.xml
+++ b/galaxy/mzml2isa/mzml2isa.xml
@@ -1,6 +1,7 @@
-<tool id="mzml2isa" name="mzml2isa" version="1.1.1+galaxy0">
+<tool id="mzml2isa" name="mzml2isa" version="1.1.1+galaxy1">
     <description>Parser to get meta information from mzML files and create an ISA-Tab structure</description>
     <requirements>
+        <requirement type="package">zip</requirement>
         <requirement type="package" version="1.1.1">mzml2isa</requirement>
     </requirements>
     <stdio>
@@ -45,7 +46,6 @@
 	 && zip isa.zip i_* a_* s_* && mv isa.zip "$ISA_zip";
     ]]>
     </command>
-
     <inputs>
         <param name="name_of_study" type="text" label="Name study" help="This should not contain any spaces as the name will be used a prefix for ISA-tab file names" />
         <conditional name="input">


### PR DESCRIPTION
In some configurations, "zip" will be missing as being installed as default on the command line.

This fixes this issue by adding "zip" as a required dependency in the tool xml.

The zipping is done after mzml2isa is ran (so is not a dependency of mzml2isa).

Also removed lintr from the github workflows (as no R is used)